### PR TITLE
Fix: Clear token response before emitting logout event

### DIFF
--- a/lib/src/wrapper.dart
+++ b/lib/src/wrapper.dart
@@ -145,6 +145,7 @@ class KeycloakWrapper {
 
       await _appAuth.endSession(request);
       await _secureStorage.deleteAll();
+      tokenResponse = null;
       _streamController.add(false);
       return true;
     } catch (e, s) {


### PR DESCRIPTION
## Description

Clear `tokenResponse` before emitting logout event.